### PR TITLE
don't escape ids twice when listing records

### DIFF
--- a/lib/conjur/standard_methods.rb
+++ b/lib/conjur/standard_methods.rb
@@ -43,10 +43,12 @@ module Conjur
     
     def standard_list(host, type, options)
       JSON.parse(RestClient::Resource.new(host, credentials)[type.to_s.pluralize].get(options)).collect do |item|
+        # Note that we don't want to fully_escape the ids below -- methods like #layer, #host, etc don't expect
+        # ids to be escaped, and will escape them again!.
         if item.is_a? String  # lists w/o details are just list of ids 
-          send(type, fully_escape(item)) 
+          send(type,item)
         else                  # list w/ details consists of hashes
-          send(type, fully_escape(item['id'])).tap { |obj| obj.attributes=item }
+          send(type, item['id']).tap { |obj| obj.attributes=item }
         end
       end
     end


### PR DESCRIPTION
The problem here was that when given an id with characters like `'/'`, fully_escape would be called on an id like `'pubkeys-1.0/public-keys'`, to give` 'pubkeys-1.0%2Fpublic-keys'`.  This would then be passed to a `standard_show` method like `layer` or `group`, which would `fully_escape` the id again, replacing the `'%'` character with `'%25'` before putting it in the objects's `url`.  For the id above, you'd end up with `'pubkeys-1.0%252Fpublic-keys'`.  The double escape would result in bogus behavior like

```ruby
api.layers[0].exists? 
# => false
```

when `api.layers[0].id` happens to contain an escaped character like `'/'`.