### PR TITLE
Refactor our patches to RestClient::Resource into a new class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Refactor REST client code
 * Bugfix: Don't escape ids twice when listing records
 * Add a stub so that require 'conjur-api' works
 

--- a/lib/conjur-api/version.rb
+++ b/lib/conjur-api/version.rb
@@ -19,6 +19,6 @@
 
 module Conjur
   class API
-    VERSION = "4.13.0"
+    VERSION = "4.14.0"
   end
 end

--- a/lib/conjur/annotations.rb
+++ b/lib/conjur/annotations.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -81,7 +81,8 @@ module Conjur
       @resource.invalidate do
         @annotations_hash = nil
         path = [@resource.account,'annotations', @resource.kind, @resource.identifier].join '/'
-        RestClient::Resource.new(Conjur::Authz::API.host, @resource.options)[path].put name: name, value: value
+        Conjur::REST.new(Conjur::Authz::API.host, @resource.options)[path]\
+            .put name: name, value: value
       end
     end
     

--- a/lib/conjur/api.rb
+++ b/lib/conjur/api.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -40,36 +40,5 @@ require 'conjur/audit-api'
 require 'conjur/core-api'
 require 'conjur/layer-api'
 require 'conjur/pubkeys-api'
+require 'conjur/rest'
 require 'conjur-api/version'
-
-class RestClient::Resource
-  include Conjur::Escape
-  include Conjur::LogSource
-  include Conjur::Cast
-  extend  Conjur::BuildFromResponse
-  
-  def core_conjur_account
-    Conjur::Core::API.conjur_account
-  end
-  
-  def to_json(options = {})
-    {}
-  end
-  
-  def conjur_api
-    Conjur::API.new_from_token token
-  end
-  
-  def token
-    authorization = options[:headers][:authorization]
-    if authorization && authorization.to_s[/^Token token="(.*)"/]
-      JSON.parse(Base64.decode64($1))
-    else
-      raise AuthorizationError.new("Authorization missing")
-    end
-  end
-
-  def username
-    options[:user] || options[:username]
-  end
-end

--- a/lib/conjur/api/audit.rb
+++ b/lib/conjur/api/audit.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -45,7 +45,9 @@ module Conjur
       if options[:follow]
         follow_events path, &block
       else
-        parse_response(RestClient::Resource.new(Conjur::Audit::API.host, credentials)[path].get).tap do |events|
+        parse_response(
+          Conjur::REST.new(Conjur::Audit::API.host, credentials)[path].get
+        ).tap do |events|
           block.call(events) if block
         end
       end

--- a/lib/conjur/api/authn.rb
+++ b/lib/conjur/api/authn.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -28,7 +28,8 @@ module Conjur
         if Conjur.log
           Conjur.log << "Logging in #{username} via Basic authentication\n"
         end
-        RestClient::Resource.new(Conjur::Authn::API.host, user: username, password: password)['users/login'].get
+        Conjur::REST.new(Conjur::Authn::API.host,
+                         user: username, password: password)['users/login'].get
       end
 
       # Perform login by CAS authentication.
@@ -45,14 +46,18 @@ module Conjur
         if Conjur.log
           Conjur.log << "Authenticating #{username}\n"
         end
-        JSON::parse(RestClient::Resource.new(Conjur::Authn::API.host)["users/#{fully_escape username}/authenticate"].post password, content_type: 'text/plain')
+        JSON.parse(Conjur::REST.new(Conjur::Authn::API.host)\
+                  ["users/#{fully_escape username}/authenticate"]\
+                  .post password, content_type: 'text/plain')
       end
       
       def update_password username, password, new_password
         if Conjur.log
           Conjur.log << "Updating password for #{username}\n"
         end
-        RestClient::Resource.new(Conjur::Authn::API.host, user: username, password: password)['users/password'].put new_password
+        Conjur::REST.new(Conjur::Authn::API.host,
+                          user: username, password: password
+                        )['users/password'].put new_password
       end
     end
 
@@ -66,7 +71,8 @@ module Conjur
       log do |logger|
         logger << "Creating authn user #{login}"
       end
-      JSON.parse RestClient::Resource.new(Conjur::Authn::API.host, credentials)['users'].post(options.merge(login: login))
+      JSON.parse Conjur::REST.new(Conjur::Authn::API.host, credentials)\
+          ['users'].post(options.merge(login: login))
     end
   end
 end

--- a/lib/conjur/api/groups.rb
+++ b/lib/conjur/api/groups.rb
@@ -42,7 +42,8 @@ module Conjur
     # @note You can get a {Conjur::Group} by calling {Conjur::API#group}, eg.:
     #   +api.find_groups(gidnumber: 12345).map(&api.method(:group))+
     def find_groups options
-      JSON.parse(RestClient::Resource.new(Conjur::Core::API.host, credentials)["groups/search?#{options.to_query}"].get)
+      JSON.parse(Conjur::REST.new(Conjur::Core::API.host, credentials)\
+                 ["groups/search?#{options.to_query}"].get)
     end
   end
 end

--- a/lib/conjur/api/pubkeys.rb
+++ b/lib/conjur/api/pubkeys.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -44,7 +44,7 @@ module Conjur
     
     protected
     def public_keys_resource *path
-      RestClient::Resource.new(Conjur::API.pubkeys_asset_host, credentials)[public_keys_path *path]
+      Conjur::REST.new(Conjur::API.pubkeys_asset_host, credentials)[public_keys_path(*path)]
     end
     
     def public_keys_path *args

--- a/lib/conjur/api/roles.rb
+++ b/lib/conjur/api/roles.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -42,7 +42,8 @@ module Conjur
       query = {from_role: options.delete(:as_role)}
         .merge(options.slice(:ancestors, :descendants))
         .merge(roles: roles).to_query
-      Conjur::Graph.new RestClient::Resource.new(Conjur::Authz::API.host, credentials)["#{Conjur.account}/roles?#{query}"].get
+      Conjur::Graph.new Conjur::REST.new(Conjur::Authz::API.host, credentials)\
+          ["#{Conjur.account}/roles?#{query}"].get
     end
 
     def create_role(role, options = {})

--- a/lib/conjur/api/users.rb
+++ b/lib/conjur/api/users.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -31,7 +31,8 @@ module Conjur
     end
 
     def find_users options
-      JSON.parse( RestClient::Resource.new(Conjur::Core::API.host, credentials)["users/search?#{options.to_query}"].get )
+      JSON.parse(Conjur::REST.new(Conjur::Core::API.host, credentials)\
+                 ["users/search?#{options.to_query}"].get)
     end
   end
 end

--- a/lib/conjur/api/variables.rb
+++ b/lib/conjur/api/variables.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -35,7 +35,8 @@ module Conjur
       raise ArgumentError, "Variables list is empty" if varlist.empty?
       opts = "?vars=#{varlist.map { |v| fully_escape(v) }.join(',')}"
       begin 
-        resp = RestClient::Resource.new(Conjur::Core::API.host, self.credentials)['variables/values'+opts].get
+        resp = Conjur::REST.new(Conjur::Core::API.host, credentials)\
+            ['variables/values' + opts].get
         return JSON.parse( resp.body ) 
       rescue RestClient::ResourceNotFound 
         return Hash[ *varlist.map { |v| [ v, variable(v).value ]  }.flatten ]  

--- a/lib/conjur/base.rb
+++ b/lib/conjur/base.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2014 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -18,11 +18,8 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-require 'rest-client'
 require 'json'
 require 'base64'
-
-require 'conjur/patches/rest-client'
 
 require 'conjur/exists'
 require 'conjur/has_attributes'
@@ -31,6 +28,7 @@ require 'conjur/path_based'
 require 'conjur/escape'
 require 'conjur/log'
 require 'conjur/log_source'
+require 'conjur/rest'
 require 'conjur/standard_methods'
 require 'conjur/cast'
 

--- a/lib/conjur/core-api.rb
+++ b/lib/conjur/core-api.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -39,7 +39,7 @@ module Conjur
         end
         
         def info
-          @info ||= JSON.parse RestClient::Resource.new(Conjur::Core::API.host)['info'].get
+          @info ||= JSON.parse Conjur::REST.new(Conjur::Core::API.host)['info'].get
         end
       end
     end

--- a/lib/conjur/deputy.rb
+++ b/lib/conjur/deputy.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -19,7 +19,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 module Conjur
-  class Deputy < RestClient::Resource
+  class Deputy < Conjur::REST
     include Exists
     include HasId
     include HasIdentifier

--- a/lib/conjur/group.rb
+++ b/lib/conjur/group.rb
@@ -18,7 +18,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 module Conjur
-  class Group < RestClient::Resource
+  class Group < Conjur::REST
     include ActsAsAsset
     include ActsAsRole
     

--- a/lib/conjur/layer.rb
+++ b/lib/conjur/layer.rb
@@ -1,5 +1,5 @@
 module Conjur
-  class Layer < RestClient::Resource
+  class Layer < Conjur::REST
     include ActsAsAsset
     include ActsAsRole
     
@@ -9,7 +9,7 @@ module Conjur
         logger << "Adding host #{hostid} to layer #{id}"
       end
       invalidate do
-        RestClient::Resource.new(self['hosts'].url, options).post(hostid: hostid) 
+        Conjur::REST.new(self['hosts'].url, options).post(hostid: hostid)
       end
     end
     
@@ -19,7 +19,7 @@ module Conjur
         logger << "Removing host #{hostid} from layer #{id}"
       end
       invalidate do
-        RestClient::Resource.new(self["hosts/#{fully_escape hostid}"].url, options).delete
+        Conjur::REST.new(self["hosts/#{fully_escape hostid}"].url, options).delete
       end
     end
     

--- a/lib/conjur/path_based.rb
+++ b/lib/conjur/path_based.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -35,7 +35,7 @@ module Conjur
     end
     
     def tokens
-      self.url[RestClient::Resource.new(Conjur::Authz::API.host)[''].url.length..-1].split('/')
+      url[Conjur::REST.new(Conjur::Authz::API.host)[''].url.length..-1].split('/')
     end
   end
 end

--- a/lib/conjur/resource.rb
+++ b/lib/conjur/resource.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -21,7 +21,7 @@
 require 'conjur/annotations'
 
 module Conjur
-  class Resource < RestClient::Resource
+  class Resource < Conjur::REST
     include HasAttributes
     include PathBased
     include Exists
@@ -55,7 +55,10 @@ module Conjur
     
     # Lists roles that have a specified permission on the resource.
     def permitted_roles(permission, options = {})
-      JSON.parse RestClient::Resource.new(Conjur::Authz::API.host, self.options)["#{account}/roles/allowed_to/#{permission}/#{path_escape kind}/#{path_escape identifier}"].get(options)
+      JSON.parse Conjur::REST.new(Conjur::Authz::API.host, self.options)[
+        [account, 'roles', 'allowed_to', permission,
+         path_escape(kind), path_escape(identifier)].join('/')
+        ].get(options)
     end
     
     # Changes the owner of a resource
@@ -148,7 +151,7 @@ module Conjur
       path += "/#{kind}" if kind
       query = opts.slice(:acting_as, :limit, :offset, :search)
       path += "?#{query.to_query}" unless query.empty?
-      resource = RestClient::Resource.new(host, credentials)[path]
+      resource = Conjur::REST.new(host, credentials)[path]
       
       JSON.parse resource.get
     end

--- a/lib/conjur/rest.rb
+++ b/lib/conjur/rest.rb
@@ -24,6 +24,7 @@ require 'conjur/cast'
 require 'conjur/escape'
 require 'conjur/log_source'
 require 'conjur/patches/rest-client'
+require 'conjur-api/version'
 
 module Conjur
 # A REST resource with Conjur-related functionality.

--- a/lib/conjur/rest.rb
+++ b/lib/conjur/rest.rb
@@ -29,34 +29,111 @@ module Conjur
 # A REST resource with Conjur-related functionality.
 # Base for all REST references in the library.
   class REST < RestClient::Resource
-    include Conjur::Escape
-    include Conjur::LogSource
-    include Conjur::Cast
-    extend Conjur::BuildFromResponse
+    # Instance methods separated into a module to support compatibility code.
+    # Please roll back into REST class on 5.0.
+    module InstanceMethods
+      include Conjur::Cast
+      include Conjur::Escape
+      include Conjur::LogSource
 
-    def core_conjur_account
-      Conjur::Core::API.conjur_account
-    end
+      def default_options
+        {
+          verify_ssl: true,
+          ssl_cert_store: OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE
+        }
+      end
 
-    def to_json _options = {}
-      {}
-    end
+      def core_conjur_account
+        Conjur::Core::API.conjur_account
+      end
 
-    def conjur_api
-      Conjur::API.new_from_token token
-    end
+      def to_json _options = {}
+        {}
+      end
 
-    def token
-      authorization = options[:headers][:authorization]
-      if authorization && (token = authorization.to_s[/^Token token="(.*)"/, 1])
-        JSON.parse(Base64.decode64(token))
-      else
-        fail AuthorizationError, "Authorization missing"
+      def conjur_api
+        Conjur::API.new_from_token token
+      end
+
+      def token
+        authorization = options[:headers][:authorization]
+        if authorization && (token = authorization.to_s[/^Token token="(.*)"/, 1])
+          JSON.parse(Base64.decode64(token))
+        else
+          fail AuthorizationError, "Authorization missing"
+        end
+      end
+
+      def username
+        options[:user] || options[:username]
+      end
+
+      # can be removed after rolling back this module into Conjur::REST
+      def self.included base
+        Conjur::Escape.included base
       end
     end
 
-    def username
-      options[:user] || options[:username]
+    # deprecation warning handling code
+    # can be removed after dropping the compatibility code below
+    class << self
+      def show_deprecation_warning
+        return if Conjur::API::VERSION < "4.15.0" # give people some time to upgrade
+        gem = find_deprecated_gem caller_locations(2, 1).first.absolute_path
+        return unless gem && gem.name =~ /conjur-asset/
+        $stderr.puts """
+WARNING: Deprecated direct call to RestClient::Resource instead of Conjur::REST
+from #{caller(3, ENV['DEBUG'] ? nil : 1).join("\n")}.
+
+Please update the #{gem.name} gem.
+        """
+      end
+
+      # make sure path really is appropriate for deprecation warning,
+      # that we haven't warned already about this file and find the gem it
+      # belongs to
+      def find_deprecated_gem path
+        return if path == __FILE__
+        return unless (gem = gem_of_file path)
+        return if (@deprecation_warnings ||= []).include? path
+        @deprecation_warnings << path
+        gem
+      end
+
+      # tries to find gem of the file at given path by searching for
+      # successively longer suffixes
+      def gem_of_file path
+        components = path.split('/')
+        (1..components.length).map do |suffix_len|
+          components[-suffix_len..-1].join('/')
+        end.map(&Gem::Specification.method(:find_by_path)).compact.first
+      end
+    end
+
+    # Uncomment after removing compatibility code
+    #
+    # def initialize url, options = nil, &block
+    #   super url, default_options.merge(options || {}), &block
+    # end
+
+    include InstanceMethods
+    extend Conjur::BuildFromResponse
+  end
+end
+
+if Conjur::API::VERSION >= '5'
+  fail 'please remove deprecated code from lib/conjur/rest.rb'
+else
+  # deprecated monkey patch for the benefit of old plugins
+  class RestClient::Resource
+    include Conjur::REST::InstanceMethods
+    extend Conjur::BuildFromResponse
+
+    alias_method :initialize_without_conjur_deprecation, :initialize
+
+    def initialize url, options = nil, &block
+      Conjur::REST.show_deprecation_warning
+      initialize_without_conjur_deprecation url, default_options.merge(options || {}), &block
     end
   end
 end

--- a/lib/conjur/role.rb
+++ b/lib/conjur/role.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -21,7 +21,7 @@
 require 'conjur/role_grant'
 
 module Conjur
-  class Role < RestClient::Resource
+  class Role < Conjur::REST
     include Exists
     include PathBased
 

--- a/lib/conjur/secret.rb
+++ b/lib/conjur/secret.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -19,7 +19,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 module Conjur
-  class Secret < RestClient::Resource
+  class Secret < Conjur::REST
     include ActsAsAsset
     
     def value

--- a/lib/conjur/standard_methods.rb
+++ b/lib/conjur/standard_methods.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -37,12 +37,14 @@ module Conjur
       end
       options ||= {}
       options[:id] = id if id
-      resp = RestClient::Resource.new(host, credentials)[type.to_s.pluralize].post(options)
+      resp = Conjur::REST.new(host, credentials)[type.to_s.pluralize].post(options)
       "Conjur::#{type.to_s.classify}".constantize.build_from_response(resp, credentials)
     end
     
     def standard_list(host, type, options)
-      JSON.parse(RestClient::Resource.new(host, credentials)[type.to_s.pluralize].get(options)).collect do |item|
+      JSON.parse(Conjur::REST.new(host, credentials)[type.to_s.pluralize]\
+                  .get(options)
+                ).map do |item|
         # Note that we don't want to fully_escape the ids below -- methods like #layer, #host, etc don't expect
         # ids to be escaped, and will escape them again!.
         if item.is_a? String  # lists w/o details are just list of ids 

--- a/lib/conjur/user.rb
+++ b/lib/conjur/user.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 Conjur Inc
+# Copyright (C) 2013-2015 Conjur Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -22,7 +22,7 @@ module Conjur
   class InvalidToken < Exception
   end
   
-  class User < RestClient::Resource
+  class User < Conjur::REST
     include ActsAsAsset
     include ActsAsUser
     

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -271,9 +271,12 @@ describe Conjur::API do
       end
     end
 
-    context "from logged-in RestClient::Resource" do
+    context "from logged-in Conjur::REST" do
       let(:token_encoded) { Base64.strict_encode64(token.to_json) }
-      let(:resource) { RestClient::Resource.new("http://example.com", { headers: { authorization: "Token token=\"#{token_encoded}\"" } })}
+      let(:resource) do
+        Conjur::REST.new("http://example.com",
+          headers: { authorization: "Token token=\"#{token_encoded}\"" })
+      end
       it "can construct a new API instance" do
         api = resource.conjur_api
         expect(api.credentials[:headers][:authorization]).to eq("Token token=\"#{token_encoded}\"")

--- a/spec/lib/standard_methods_spec.rb
+++ b/spec/lib/standard_methods_spec.rb
@@ -14,7 +14,7 @@ describe Conjur::StandardMethods do
   before do
     subject.extend Conjur::StandardMethods
     allow(subject).to receive(:fully_escape){|x|x}
-    allow(RestClient::Resource).to receive(:new).with(host, credentials).and_return rest_resource
+    allow(Conjur::REST).to receive(:new).with(host, credentials).and_return rest_resource
     allow(rest_resource).to receive(:[]).with('widgets').and_return subresource
     stub_const 'Conjur::Widget', widget_class
   end


### PR DESCRIPTION
This change puts our changes to RestClient::Resource into a new derived class called Conjur::REST instead. This makes it potentially more compatible with third-party code.
