### PR TITLE
Feature: Cert config improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.16.0
+  * Add ssl_certificate option to allow certs to be provided as strings (helpful in heroku)
+  * Add `Conjur::Configuration#apply_cert_config!` method to add certs from `#cert_file` and `#ssl_certificate` 
+     to the default cert store.
 # v4.15.0
  * Extensive documentation improvements
  * A few additional methoods, for example `Conjur::API#public_key_names`.

--- a/lib/conjur-api/version.rb
+++ b/lib/conjur-api/version.rb
@@ -19,6 +19,6 @@
 
 module Conjur
   class API
-    VERSION = "4.15.1"
+    VERSION = "4.16.0"
   end
 end

--- a/lib/conjur-api/version.rb
+++ b/lib/conjur-api/version.rb
@@ -19,6 +19,6 @@
 
 module Conjur
   class API
-    VERSION = "4.15.0"
+    VERSION = "4.15.1"
   end
 end

--- a/lib/conjur/configuration.rb
+++ b/lib/conjur/configuration.rb
@@ -18,6 +18,8 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
+
+require 'set'
 module Conjur
   
   class << self
@@ -388,6 +390,16 @@ module Conjur
     # @return [String, nil] path to the certificate file, or nil if you aren't using one.
     add_option :cert_file
 
+    # @!attribute ssl_certificate
+    #
+    # Contents of a certificate file.  This can be used instead of :cert_file in environments like Heroku
+    # where your ability to save a certificate to a file is restricted (if you try to do so , you'll get an error about
+    # the certificate not being in the proper directory, and you can't write to the proper directory).
+    #
+    # @see cert_file
+    add_option :ssl_certificate
+
+
     private
 
     def global_service_url(service_name, service_port_offset)
@@ -428,5 +440,6 @@ module Conjur
     def herokuize name
       name.downcase.gsub(/[^a-z0-9\-]/, '-')
     end
+
   end
 end


### PR DESCRIPTION
Now accepts `ssl_certificate` (`"CONJUR_SSL_CERTIFICATE"`) option containing a certificate as a string, and adds a `apply_cert_config!` method to `Conjur::Configuration` to handle the trickiness of trusting the certs in `ssl_certificate` and `cert_file`.  No breaking changes.