### PR TITLE
Allow retrieval of values of expired variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v4.20.2
+
+* `Conjur::Variable#value` now accepts a `show_expired` option. When `show_expired` is `true`, the variable's value will be returned, even if the variable has expired. Requires v4.6.2(?) of the expiration service.
+* (should we document authentication using authn-local?)
+* `Conjur::API#variable_expirations` now correctly returns a collection of Variables, rather than a Hash
+
 # v4.20.1
 
 * BUGFIX: Better handling for unicode and special characters in user ids.

--- a/conjur-api.gemspec
+++ b/conjur-api.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rest-client', '~> 1.7', '>= 1.7.3'
   gem.add_dependency 'activesupport'
   gem.add_dependency 'semantic'
-  gem.add_dependency 'net_http_unix', '~> 0.2'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'spork'

--- a/conjur-api.gemspec
+++ b/conjur-api.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rest-client', '~> 1.7', '>= 1.7.3'
   gem.add_dependency 'activesupport'
   gem.add_dependency 'semantic'
-  
+  gem.add_dependency 'net_http_unix', '~> 0.2'
+
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'spork'
   gem.add_development_dependency 'rspec', '~> 3'

--- a/lib/conjur/api/authn.rb
+++ b/lib/conjur/api/authn.rb
@@ -79,7 +79,7 @@ module Conjur
       # @param [String] username The username or host id for which we want a token
       # @param [String] password The password or api key
       # @return [String] A JSON formatted authentication token.
-      def authenticate username, password
+      def authenticate_remote username, password
         if Conjur.log
           Conjur.log << "Authenticating #{username}\n"
         end
@@ -96,6 +96,13 @@ module Conjur
         JSON.parse(resp.body)
       end
 
+      def authenticate username, password=nil
+        if Conjur.configuration.authn_local
+          authenticate_local username
+        else
+          authenticate_remote username, password
+        end
+      end
 
       # Change a user's password.  To do this, you must have the user's current password.  This does not change or rotate
       #   api keys.  However, you *can*  use the user's api key as the *current* password, if the user was not created

--- a/lib/conjur/api/authn.rb
+++ b/lib/conjur/api/authn.rb
@@ -79,7 +79,7 @@ module Conjur
       # @param [String] username The username or host id for which we want a token
       # @param [String] password The password or api key
       # @return [String] A JSON formatted authentication token.
-      def authenticate username, password
+      def authenticate username, password = nil
         if Conjur.log
           Conjur.log << "Authenticating #{username}\n"
         end

--- a/lib/conjur/api/authn.rb
+++ b/lib/conjur/api/authn.rb
@@ -89,8 +89,9 @@ module Conjur
                else
                  require 'net_http_unix'
                  client = NetX::HTTPUnix.new('unix:///run/authn-local/.socket')
-                 client.request(New::HTTP::Post.new(rsrc)).body
+                 client.request(Net::HTTP::Post.new(rsrc)).body
                end
+        JSON.parse(body)
       end
 
 

--- a/lib/conjur/api/authn.rb
+++ b/lib/conjur/api/authn.rb
@@ -97,7 +97,7 @@ module Conjur
       end
 
       def authenticate username, password=nil
-        if Conjur.configuration.authn_local
+        if authenticate_locally?
           authenticate_local username
         else
           authenticate_remote username, password
@@ -159,5 +159,12 @@ module Conjur
       end
       JSON.parse RestClient::Resource.new(Conjur::Authn::API.host, credentials)['users'].post(options.merge(login: login))
     end
+
+    private
+    def authenticate_locally?
+      # XXX add check for authn-local's socket
+      Conjur.configuration.use_authn_local
+    end
+
   end
 end

--- a/lib/conjur/api/authn.rb
+++ b/lib/conjur/api/authn.rb
@@ -83,7 +83,14 @@ module Conjur
         if Conjur.log
           Conjur.log << "Authenticating #{username}\n"
         end
-        JSON::parse(RestClient::Resource.new(Conjur::Authn::API.host)["users/#{fully_escape username}/authenticate"].post password, content_type: 'text/plain')
+        rsrc = "users/#{fully_escape username}/authenticate"
+        body = unless Conjur.configuration.authn_local
+                 RestClient::Resource.new(Conjur::Authn::API.host)[rsrc].post password, content_type: 'text/plain'
+               else
+                 require 'net_http_unix'
+                 client = NetX::HTTPUnix.new('unix:///run/authn-local/.socket')
+                 client.request(New::HTTP::Post.new(rsrc)).body
+               end
       end
 
 

--- a/lib/conjur/api/variables.rb
+++ b/lib/conjur/api/variables.rb
@@ -126,7 +126,12 @@ module Conjur
     def variable_expirations(interval = nil)
       duration = interval.try { |i| i.respond_to?(:to_str) ? i : "PT#{i.to_i}S" }
       params = {}.tap { |p| p.merge!({:params => {:duration => duration }}) if duration }
-      JSON.parse(RestClient::Resource.new(Conjur::Core::API.host, self.credentials)['variables/expirations'].get(params).body)
+      JSON.parse(RestClient::Resource.new(Conjur::Core::API.host, self.credentials)['variables/expirations'].get(params)).collect do |item|
+        # the JSON objects from /variable/expirations look like
+        # resources rather than variables, so their ids are
+        # fully-qualified.
+        variable(item['id'].split(':')[-1])
+      end
     end
 
     #@!endgroup

--- a/lib/conjur/api/variables.rb
+++ b/lib/conjur/api/variables.rb
@@ -125,8 +125,9 @@ module Conjur
     # return [Hash] variable expirations that occur within the interval
     def variable_expirations(interval = nil)
       duration = interval.try { |i| i.respond_to?(:to_str) ? i : "PT#{i.to_i}S" }
-      params = {}.tap { |p| p.merge!({:params => {:duration => duration }}) if duration }
-      JSON.parse(RestClient::Resource.new(Conjur::Core::API.host, self.credentials)['variables/expirations'].get(params)).collect do |item|
+      params = {}
+      params[:params] = {:duration => duration} if duration
+      JSON.parse(RestClient::Resource.new(Conjur::Core::API.host, self.credentials)['variables/expirations'].get(params).body).collect do |item|
         # the JSON objects from /variable/expirations look like
         # resources rather than variables, so their ids are
         # fully-qualified.

--- a/lib/conjur/configuration.rb
+++ b/lib/conjur/configuration.rb
@@ -403,7 +403,12 @@ module Conjur
     # @see cert_file
     add_option :ssl_certificate
 
-    add_option :authn_local, :default => false
+    # NB: use_authn_local doesn't need external documentation
+    #
+    # If true (the default), use authn-local if it's available
+    # (indicated by the existence of its socket). Otherwise,
+    # authenticate with authn.
+    add_option :use_authn_local, :default => true
 
 
     # Add the certificate configured by the {#ssl_certificate} and {#cert_file} options to the certificate

--- a/lib/conjur/configuration.rb
+++ b/lib/conjur/configuration.rb
@@ -403,7 +403,6 @@ module Conjur
     # @see cert_file
     add_option :ssl_certificate
 
-    add_option :authn_local, :default => false
 
 
     # Add the certificate configured by the {#ssl_certificate} and {#cert_file} options to the certificate

--- a/lib/conjur/configuration.rb
+++ b/lib/conjur/configuration.rb
@@ -403,6 +403,7 @@ module Conjur
     # @see cert_file
     add_option :ssl_certificate
 
+    add_option :authn_local, :default => false
 
 
     # Add the certificate configured by the {#ssl_certificate} and {#cert_file} options to the certificate

--- a/lib/conjur/variable.rb
+++ b/lib/conjur/variable.rb
@@ -200,9 +200,13 @@ module Conjur
     #
     # @param [Integer] version the **1 based** version.
     # @return [String] the value of the variable
-    def value(version = nil)
+    def value(version = nil, show_expired = false)
       url = 'value'
-      url << "?version=#{version}" if version
+      params = {}.tap {|h|
+        h['version'] = version if version
+        h['show_expired'] = show_expired if show_expired
+      }
+      url << '?' + params.to_query unless params.empty?
       self[url].get.body
     end
 

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -36,7 +36,7 @@ describe Conjur::Variable do
       expect(subject.value).to eq("the-value")
     end
 
-    it "parametrizes the request with a version" do
+    it "parameterizes the request with a version" do
       allow_request(
         method: :get,
         url: "#{url}/value?version=42",
@@ -44,6 +44,27 @@ describe Conjur::Variable do
       ).and_return(double "response", body: "the-value")
       expect(subject.value(42)).to eq("the-value")
     end
+
+    it 'will show the latest expired version' do
+      allow_request(
+        :method => :get,
+        :url => "#{url}/value?show_expired=true",
+        :headers => {}
+        ).and_return(double('response', :body => 'the-value'))
+      expect(subject.value(nil, true)).to eq('the-value')
+    end
+    
+    it 'will show some other version, even if expired' do
+      allow_request(
+        :method => :get,
+        # Hash.to_query (used to build the query string for this
+        # request) sorts the params into lexicographic order
+        :url => "#{url}/value?show_expired=true&version=42",
+        :headers => {}
+        ).and_return(double('response', :body => 'the-value'))
+      expect(subject.value(42, true)).to eq('the-value')
+    end
+
   end
 
   describe '#expire' do


### PR DESCRIPTION
Makes return value from `API::variable_expirations` a collection of `Conjur::Variable`s, rather than a `Hash`.

Adds ability to authenticate against `authn-local`.

`CHANGELOG` has some questions in it.