### PR TITLE
Add support of retrieval of values of expired variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.21.1 (unreleased)
+
+* Add `show_expired` argument to `Conjur::Variable#value` to allow
+  retrieval of values of expired variables.
+
 # v4.21.0
 
 * Add extensible Bootstrap commands as API methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 * Add `show_expired` argument to `Conjur::Variable#value` to allow
   retrieval of values of expired variables.
-
 * Fix `Conjur::API#variable_expirations` so it returns an array of
   `Conjur::Variable`, rather than a `Hash`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Add `show_expired` argument to `Conjur::Variable#value` to allow
   retrieval of values of expired variables.
 
+* Fix `Conjur::API#variable_expirations` so it returns an array of
+  `Conjur::Variable`, rather than a `Hash`.
+
 # v4.21.0
 
 * Add extensible Bootstrap commands as API methods.

--- a/lib/conjur/api/variables.rb
+++ b/lib/conjur/api/variables.rb
@@ -126,7 +126,12 @@ module Conjur
     def variable_expirations(interval = nil)
       duration = interval.try { |i| i.respond_to?(:to_str) ? i : "PT#{i.to_i}S" }
       params = {}.tap { |p| p.merge!({:params => {:duration => duration }}) if duration }
-      JSON.parse(RestClient::Resource.new(Conjur::Core::API.host, self.credentials)['variables/expirations'].get(params).body)
+      JSON.parse(RestClient::Resource.new(Conjur::Core::API.host, self.credentials)['variables/expirations'].get(params)).collect do |item|
+        # the JSON objects from /variable/expirations look like
+        # resources rather than variables, so their ids are
+        # fully-qualified.
+        variable(item['id'].split(':')[-1])
+      end
     end
 
     #@!endgroup

--- a/lib/conjur/api/variables.rb
+++ b/lib/conjur/api/variables.rb
@@ -125,8 +125,9 @@ module Conjur
     # return [Hash] variable expirations that occur within the interval
     def variable_expirations(interval = nil)
       duration = interval.try { |i| i.respond_to?(:to_str) ? i : "PT#{i.to_i}S" }
-      params = {}.tap { |p| p.merge!({:params => {:duration => duration }}) if duration }
-      JSON.parse(RestClient::Resource.new(Conjur::Core::API.host, self.credentials)['variables/expirations'].get(params)).collect do |item|
+      params = {}
+      params[:params] = {:duration => duration} if duration
+      JSON.parse(RestClient::Resource.new(Conjur::Core::API.host, self.credentials)['variables/expirations'].get(params).body).collect do |item|
         # the JSON objects from /variable/expirations look like
         # resources rather than variables, so their ids are
         # fully-qualified.

--- a/lib/conjur/variable.rb
+++ b/lib/conjur/variable.rb
@@ -200,9 +200,13 @@ module Conjur
     #
     # @param [Integer] version the **1 based** version.
     # @return [String] the value of the variable
-    def value(version = nil)
+    def value(version = nil, show_expired = false)
       url = 'value'
-      url << "?version=#{version}" if version
+      params = {}.tap {|h|
+        h['version'] = version if version
+        h['show_expired'] = show_expired if show_expired
+      }
+      url << '?' + params.to_query unless params.empty?
       self[url].get.body
     end
 

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -36,7 +36,7 @@ describe Conjur::Variable do
       expect(subject.value).to eq("the-value")
     end
 
-    it "parametrizes the request with a version" do
+    it "parameterizes the request with a version" do
       allow_request(
         method: :get,
         url: "#{url}/value?version=42",
@@ -44,6 +44,27 @@ describe Conjur::Variable do
       ).and_return(double "response", body: "the-value")
       expect(subject.value(42)).to eq("the-value")
     end
+
+    it 'will show the latest expired version' do
+      allow_request(
+        :method => :get,
+        :url => "#{url}/value?show_expired=true",
+        :headers => {}
+        ).and_return(double('response', :body => 'the-value'))
+      expect(subject.value(nil, true)).to eq('the-value')
+    end
+    
+    it 'will show some other version, even if expired' do
+      allow_request(
+        :method => :get,
+        # Hash.to_query (used to build the query string for this
+        # request) sorts the params into lexicographic order
+        :url => "#{url}/value?show_expired=true&version=42",
+        :headers => {}
+        ).and_return(double('response', :body => 'the-value'))
+      expect(subject.value(42, true)).to eq('the-value')
+    end
+
   end
 
   describe '#expire' do


### PR DESCRIPTION
Fix `Conjur::API#variable_expirations` so it returns an array of `Conjur::Variable` instead of a `Hash`.