### PR TITLE
Escape spaces in URLs with `%20` instead of `+`

### DIFF
--- a/lib/conjur/escape.rb
+++ b/lib/conjur/escape.rb
@@ -34,9 +34,9 @@ module Conjur
       # @param [String] str the string to escape
       # @return [String] the escaped string
       def fully_escape(str)
-        require 'cgi'
-        CGI.escape(str.to_s)
+	CGI.escape str	
       end
+
 
       # Escape a URI path component.
       #

--- a/lib/conjur/escape.rb
+++ b/lib/conjur/escape.rb
@@ -40,7 +40,7 @@ module Conjur
       def fully_escape(str)
         # CGI escape uses + for spaces, which our services don't support :-(
         # We just gsub it.
-        CGI.escape(str).gsub('+', '%20')
+        CGI.escape(str.to_s).gsub('+', '%20')
       end
 
 

--- a/lib/conjur/escape.rb
+++ b/lib/conjur/escape.rb
@@ -38,12 +38,9 @@ module Conjur
       # @param [String] str the string to escape
       # @return [String] the escaped string
       def fully_escape(str)
-        # This is copied from CGI.escape - the difference is that
-        # here we sub spaces to '%20'.
-        encoding = str.encoding
-        str.b.gsub(/([ ]|[^ a-zA-Z0-9_.-]+)/) do |m|
-          '%' + m.unpack('H2' * m.bytesize).join('%').upcase
-        end.force_encoding(encoding)
+        # CGI escape uses + for spaces, which our services don't support :-(
+        # We just gsub it.
+        CGI.escape(str).gsub('+', '%20')
       end
 
 

--- a/lib/conjur/escape.rb
+++ b/lib/conjur/escape.rb
@@ -31,10 +31,19 @@ module Conjur
       #   fully_escape 'foo/bar@baz'
       #   # => "foo%2Fbar%40baz"
       #
+      # @example
+      #   fully_escape 'test/Domain Controllers'
+      #   # => "test%2FDomain%20Controllers"
+      #
       # @param [String] str the string to escape
       # @return [String] the escaped string
       def fully_escape(str)
-	CGI.escape str	
+        # This is copied from CGI.escape - the difference is that
+        # here we sub spaces to '%20'.
+        encoding = str.encoding
+        str.b.gsub(/([ ]|[^ a-zA-Z0-9_.-]+)/) do |m|
+          '%' + m.unpack('H2' * m.bytesize).join('%').upcase
+        end.force_encoding(encoding)
       end
 
 

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -390,4 +390,21 @@ describe Conjur::API do
       end
     end
   end
+
+  describe 'url escapes' do
+    let(:urls){[
+        'foo/bar@baz',
+        '/test/some group with spaces'
+    ]}
+
+    describe '#fully_escape' do
+      let(:expected){[
+        'foo%2Fbar%40baz',
+        '%2Ftest%2Fsome%20group%20with%20spaces'
+      ]}
+      it 'escapes the urls correctly' do
+        expect(urls.map{|u| Conjur::API.fully_escape u}).to eq(expected)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Our services don't handle `+` signs in URL path components correctly.  This breaks (among other things) ldap-sync with default AD groups (e.g. `Domain Controllers`) that contain spaces in their common names.

This PR changes the `Conjur::Escape#fully_escape` method to use a slightly modified version of `CGI.escape` to encode spaces with `%20` instead of `+`.

The original `CGI.escape` method can be seen here: https://github.com/ruby/ruby/blob/trunk/lib/cgi/util.rb#L8.