### PR TITLE
Don't try to refresh authentication token if not possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # v4.24.0
 
 * Add `Conjur::API#ldap_sync_now` (requires Conjur 4.7 or later).
+* Don't trust the system clock and don't check token validity. Rely on the
+  server to verify the token instead, and only try to refresh if enough time
+  has passed locally (using monotonic clock for reference where available).
+* Don't try refreshing the token if the required credentials are not available.
 
 # v4.23.0
 

--- a/conjur-api.gemspec
+++ b/conjur-api.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rdoc'
   gem.add_development_dependency 'yard'
   gem.add_development_dependency 'redcarpet'
-  gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'tins', '~> 1.6', '< 1.7.0'
   gem.add_development_dependency 'inch'
 end

--- a/lib/conjur/base.rb
+++ b/lib/conjur/base.rb
@@ -298,6 +298,9 @@ module Conjur
 
     def gettime
       Process.clock_gettime Process::CLOCK_MONOTONIC
+    rescue
+      # fall back to normal clock if there's no CLOCK_MONOTONIC
+      Time.now.to_f
     end
 
     def token_age

--- a/lib/conjur/base.rb
+++ b/lib/conjur/base.rb
@@ -232,6 +232,7 @@ module Conjur
       refresh_token if needs_token_refresh?
       return @token
     end
+
     # Credentials that can be merged with options to be passed to `RestClient::Resource` HTTP request methods.
     # These include a username and an Authorization header containing the authentication token.
     #

--- a/lib/conjur/error.rb
+++ b/lib/conjur/error.rb
@@ -1,0 +1,7 @@
+module Conjur
+  class Error < RuntimeError
+  end
+
+  class InvalidTokenError < Error
+  end
+end

--- a/lib/conjur/error.rb
+++ b/lib/conjur/error.rb
@@ -1,7 +1,0 @@
-module Conjur
-  class Error < RuntimeError
-  end
-
-  class InvalidTokenError < Error
-  end
-end

--- a/lib/conjur/user.rb
+++ b/lib/conjur/user.rb
@@ -19,9 +19,6 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 module Conjur
-  class InvalidToken < Exception
-  end
-
   # This class represents a {http://developer.conjur.net/reference/services/directory/user Conjur User}.
   class User < RestClient::Resource
     include ActsAsAsset

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -272,9 +272,9 @@ describe Conjur::API do
       end
 
       it "doesn't try to refresh an old token" do
-        token # vivify
-        time_travel 6.minutes
         expect(Conjur::API).not_to receive :authenticate
+        api.token # vivify
+        time_travel 6.minutes
         expect { api.token }.not_to raise_error
       end
     end


### PR DESCRIPTION
Also, in that case, use the (a bit) stale token for as long
as it's still valid.