### PR TITLE
Set TOKEN_STALE to 4 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.25.0
+
+* Add a workaround for a bug in Conjur <4.7 where long-running operations
+  (such as policy load) would sometimes fail with 404 after five minutes.
+
 # v4.24.1
 
 * Clarify the handling of the dry-run argument to `Conjur::API#ldap_sync_now`.

--- a/lib/conjur-api/version.rb
+++ b/lib/conjur-api/version.rb
@@ -19,6 +19,6 @@
 
 module Conjur
   class API
-    VERSION = "4.24.1"
+    VERSION = "4.25.0"
   end
 end

--- a/lib/conjur/base.rb
+++ b/lib/conjur/base.rb
@@ -288,7 +288,9 @@ module Conjur
       @token = Conjur::API.authenticate(@username, @api_key)
     end
 
-    TOKEN_STALE = 5.minutes
+    # The four minutes is to work around a bug in Conjur < 4.7 causing a 404 on 
+    # long-running operations (when the token is used right around the 5 minute mark).
+    TOKEN_STALE = 4.minutes
 
     # Checks if the token is old (or not present).
     #


### PR DESCRIPTION
This will workaround the 404 core bug for long-running operations (when the token is used right around the 5 minute mark) on older appliances.
That one minute shouldn't make that much of a difference in performance.