### PR TITLE
CON-3025 make sure @token_born gets set during initialization

### DIFF
--- a/lib/conjur/base.rb
+++ b/lib/conjur/base.rb
@@ -169,6 +169,13 @@ module Conjur
       @username = username
       @api_key = api_key
       @token = token
+      
+      # Assume that the token was recently minted, log a warning if not
+      @token_born = gettime   
+      if token && (delta = Time.now - Time.parse(token['timestamp'])) > 10
+        $stderr.puts "WARNING: token timestamp offset by #{delta.to_i} seconds"
+      end
+
       @remote_ip = remote_ip
 
       raise "Expecting ( username and api_key ) or token" unless ( username && api_key ) || token


### PR DESCRIPTION
Set `@token_born` during initialization. If it stays `nil`, this scenario can arise:

* create an api instance initialized with a token
* use another api instance to perform operations (e.g. ldap sync 1000 users) that take more than ~8 minutes (the lifetime of the token)
* try to use the first instance, get a 401 because the token has expired


