### PR TITLE
CON-3025 make sure token refresh works for long-lived API instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.25.1
+
+* Fix token refresh when using `with_privilege`, `with_audit_roles`,
+  and `with_audit_resources`.
+
 # v4.25.0
 
 * Add a workaround for a bug in Conjur <4.7 where long-running operations

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'pry'
+  gem 'pry-byebug'
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-CONJUR_VERSION=${CONJUR_VERSION:-"5.0"}
+CONJUR_VERSION=${CONJUR_VERSION:-"4.8"}
 DOCKER_IMAGE=${DOCKER_IMAGE:-"registry.tld/conjur-appliance-cuke-master:$CONJUR_VERSION-stable"}
 NOKILL=${NOKILL:-"0"}
 PULL=${PULL:-"1"}

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,7 +10,7 @@ if [ -z "$CONJUR_CONTAINER" ]; then
 	    docker pull $DOCKER_IMAGE
 	fi
 	
-	cid=$(docker run -d -v ${PWD}:/src/conjur-api $DOCKER_IMAGE)
+	cid=$(docker run --privileged -d -v ${PWD}:/src/conjur-api $DOCKER_IMAGE)
 	function finish {
     	if [ "$NOKILL" != "1" ]; then
 			docker rm -f ${cid}

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,7 +10,7 @@ if [ -z "$CONJUR_CONTAINER" ]; then
 	    docker pull $DOCKER_IMAGE
 	fi
 	
-	cid=$(docker run --privileged -d -v ${PWD}:/src/conjur-api $DOCKER_IMAGE)
+	cid=$(docker run -d -v ${PWD}:/src/conjur-api $DOCKER_IMAGE)
 	function finish {
     	if [ "$NOKILL" != "1" ]; then
 			docker rm -f ${cid}

--- a/lib/conjur-api/version.rb
+++ b/lib/conjur-api/version.rb
@@ -19,6 +19,6 @@
 
 module Conjur
   class API
-    VERSION = "4.25.0"
+    VERSION = "4.25.1"
   end
 end

--- a/lib/conjur/base.rb
+++ b/lib/conjur/base.rb
@@ -152,16 +152,20 @@ module Conjur
 
     end
     
-    # Create a new instance from a username and api key or a token.
+    # Create a new instance of a Conjur API. 
+    #
+    # You may pass either a username and api key, or just a token. If
+    # you pass a username and api key, the API will authenticate with
+    # Conjur and refresh the token automatically. If you pass only a
+    # token, you are responsible for ensuring that the token has the
+    # appropriate lifetime.
     #
     # @note You should use {Conjur::API.new_from_token} or {Conjur::API.new_from_key} instead of calling this method
     #   directly.
     #
-    # This method requires that you pass **either** a username and api_key **or** a token Hash.
-    #
     # @param [String] username the username to authenticate as
     # @param [String] api_key the api key or password to use when authenticating
-    # @param [Hash] token the token to use when making authenticated requuests.
+    # @param [Hash] token the token to use when making authenticated requests.
     # @param [String] remote_ip the optional IP address to be recorded in the audit record.
     # @param [Float] token_born the time when the token was minted
     #
@@ -173,7 +177,13 @@ module Conjur
       @token_born = token_born
       @remote_ip = remote_ip
 
-      raise "Expecting ( username and api_key ) or token" unless ( username && api_key ) || token
+      if username || api_key
+        raise "You must provide both username and password" unless username && api_key
+        raise "Only provide ( username and api_key ) or token" if token
+      elsif !token
+        raise "You must provide either ( username and api_key ) or token"
+      end
+
     end
 
     #@!attribute [r] api_key

--- a/lib/conjur/base.rb
+++ b/lib/conjur/base.rb
@@ -163,12 +163,14 @@ module Conjur
     # @param [String] api_key the api key or password to use when authenticating
     # @param [Hash] token the token to use when making authenticated requuests.
     # @param [String] remote_ip the optional IP address to be recorded in the audit record.
+    # @param [Float] token_born the time when the token was minted
     #
     # @api internal
-    def initialize username, api_key, token, remote_ip = nil
+    def initialize username, api_key, token, remote_ip = nil, token_born = nil
       @username = username
       @api_key = api_key
       @token = token
+      @token_born = token_born
       @remote_ip = remote_ip
 
       raise "Expecting ( username and api_key ) or token" unless ( username && api_key ) || token
@@ -254,14 +256,14 @@ module Conjur
     # 
     # @return The API instance.
     def with_privilege privilege
-      self.class.new(username, api_key, token, remote_ip).tap do |api|
+      self.class.new(username, api_key, token, remote_ip, @token_born).tap do |api|
         api.privilege = privilege
       end
     end
 
     def with_audit_roles role_ids
       role_ids = Array(role_ids)
-      self.class.new(username, api_key, token, remote_ip).tap do |api|
+      self.class.new(username, api_key, token, remote_ip, @token_born).tap do |api|
         # Ensure that all role ids are fully qualified
         api.audit_roles = role_ids.collect { |id| api.role(id).roleid }
       end
@@ -269,7 +271,7 @@ module Conjur
 
     def with_audit_resources resource_ids
       resource_ids = Array(resource_ids)
-      self.class.new(username, api_key, token, remote_ip).tap do |api|
+      self.class.new(username, api_key, token, remote_ip, @token_born).tap do |api|
         # Ensure that all resource ids are fully qualified
         api.audit_resources = resource_ids.collect { |id| api.resource(id).resourceid }
       end

--- a/lib/conjur/base.rb
+++ b/lib/conjur/base.rb
@@ -256,14 +256,14 @@ module Conjur
     # 
     # @return The API instance.
     def with_privilege privilege
-      self.class.new(username, api_key, token, remote_ip, @token_born).tap do |api|
+      self.class.new(username, api_key, token, remote_ip, token_born).tap do |api|
         api.privilege = privilege
       end
     end
 
     def with_audit_roles role_ids
       role_ids = Array(role_ids)
-      self.class.new(username, api_key, token, remote_ip, @token_born).tap do |api|
+      self.class.new(username, api_key, token, remote_ip, token_born).tap do |api|
         # Ensure that all role ids are fully qualified
         api.audit_roles = role_ids.collect { |id| api.role(id).roleid }
       end
@@ -271,14 +271,14 @@ module Conjur
 
     def with_audit_resources resource_ids
       resource_ids = Array(resource_ids)
-      self.class.new(username, api_key, token, remote_ip, @token_born).tap do |api|
+      self.class.new(username, api_key, token, remote_ip, token_born).tap do |api|
         # Ensure that all resource ids are fully qualified
         api.audit_resources = resource_ids.collect { |id| api.resource(id).resourceid }
       end
     end
 
     private
-
+    attr_accessor :token_born
 
     # Tries to refresh the token if possible.
     #
@@ -286,7 +286,7 @@ module Conjur
     # unavailable API key; otherwise, the new token.
     def refresh_token
       return false unless @api_key
-      @token_born = gettime
+      self.token_born = gettime
       @token = Conjur::API.authenticate(@username, @api_key)
     end
 
@@ -309,7 +309,7 @@ module Conjur
     end
 
     def token_age
-      @token_born && (gettime - @token_born)
+      token_born && (gettime - token_born)
     end
   end
 end


### PR DESCRIPTION
When `with_privilege`, `with_audit_roles`, and `with_audit_resources` create a new API instance, make sure that new instance knows when it needs to refresh its token.