### PR TITLE
Don't let activesupport float up to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   retrieving Conjur resources that have an annotation with the given
   name.
 
-* pin activesupport to v4
+* pin activesupport to < v5
 
 # v4.26.0
 

--- a/conjur-api.gemspec
+++ b/conjur-api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   
   gem.add_dependency 'rest-client', '~> 1.7', '>= 1.7.3'
-  gem.add_dependency 'activesupport', '~> 4'
+  gem.add_dependency 'activesupport', '< 5.0.0'
   gem.add_dependency 'semantic'
   
   gem.add_development_dependency 'rake'

--- a/conjur-api.gemspec
+++ b/conjur-api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   
   gem.add_dependency 'rest-client', '~> 1.7', '>= 1.7.3'
-  gem.add_dependency 'activesupport', '< 5.0.0'
+  gem.add_dependency 'activesupport'
   gem.add_dependency 'semantic'
   
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
activesupport v5 requires ruby 2.2, which is not yet an option when bundling. 