### PR TITLE
CON-3593 include log events in hash returned by ldap_sync_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.28.1
+
+* `Conjur::API#ldap_sync_policy` now returns log events generated when
+  showing a policy.
+
 # v4.28.0
 
 * Add `Conjur::API#ldap_sync_policy` to fetch the policy to use to

--- a/lib/conjur-api/version.rb
+++ b/lib/conjur-api/version.rb
@@ -19,6 +19,6 @@
 
 module Conjur
   class API
-    VERSION = "4.28.0"
+    VERSION = "4.28.1"
   end
 end

--- a/lib/conjur/api/ldapsync.rb
+++ b/lib/conjur/api/ldapsync.rb
@@ -88,15 +88,15 @@ module Conjur
     # @!endgroup
     
     private
-    def get_json(ok_key, response)
+    def get_json(key, response)
       if response.headers[:content_type] == 'text/event-stream'
-        find_ok_event(ok_key, response) || find_error_events(response)
+        find_event_by_key(key, response) || find_error_events(response)
       else
         %Q({"error": {"message": "Unexpected response from server: #{response.body}"}})
       end    
     end
 
-    def find_ok_event(key, response)
+    def find_event_by_key(key, response)
       response.body.lines.find {|l| l =~ %r(^data: {"#{key}":) }.try(:[], 6..-1)
     end
 

--- a/lib/conjur/api/ldapsync.rb
+++ b/lib/conjur/api/ldapsync.rb
@@ -106,7 +106,6 @@ module Conjur
 
     def find_error_events(response)
       find_events(response, "error").join("\n")
-      response.body.lines.collect {|l| l.match(/^data: ({"error":.*)/).try(:[], 1)}.compact.join("\n")
     end
 
     def find_events(response, key)

--- a/lib/conjur/api/ldapsync.rb
+++ b/lib/conjur/api/ldapsync.rb
@@ -82,7 +82,7 @@ module Conjur
       }
 
       response = RestClient::Resource.new(Conjur.configuration.appliance_url, headers)['ldap-sync']['search'].post(options.merge(:config_name => profile))
-      JSON.parse(get_json("groups", response))
+      JSON.parse(get_json("groups", response)).merge('events' => find_log_events(response))
     end
 
     # @!endgroup

--- a/lib/conjur/api/ldapsync.rb
+++ b/lib/conjur/api/ldapsync.rb
@@ -43,13 +43,7 @@ module Conjur
       # chunks doesn't buy us much of anything except more complicated
       # client code.
       response = RestClient::Resource.new(url, headers).get
-
-      json = if response.headers[:content_type] == 'text/event-stream'
-               find_policy_event(response) || find_error_events(response)
-             else
-               %Q({"error": {"message": "Unexpected response from server: #{response.body}"}})
-             end
-      JSON.parse(json)
+      JSON.parse(get_json("policy", response)).merge('events' => find_log_events(response))
     end
 
     # @api private
@@ -58,7 +52,8 @@ module Conjur
     # @param [String] profile name 
     # @param [Hash] options reserved
     def ldap_sync_show_profile(profile, options = {})
-      resp = RestClient::Resource.new(Conjur.configuration.appliance_url, credentials)['ldap-sync']['config'].get(options)
+      url = Conjur.configuration.appliance_url
+      resp = RestClient::Resource.new(url, credentials)['ldap-sync']['config'][profile].get(options)
       JSON.parse(resp.body)
     end
 
@@ -70,22 +65,52 @@ module Conjur
     #
     # @param [Hash] profile a hash containing the LDAP sync configuration
     # @param [Hash] options reserved
-    def ldap_sync_update_profile(profile, options = {})
+    def ldap_sync_update_profile(profile_name, profile, options = {})
       options[:json_config] = profile.to_json
-      resp = RestClient::Resource.new(Conjur.configuration.appliance_url, credentials)['ldap-sync']['config'].put(options.to_json, :content_type => 'application/json')
+      resp = RestClient::Resource.new(Conjur.configuration.appliance_url, credentials)['ldap-sync']['config'][profile_name].put(options.to_json, :content_type => 'application/json')
       JSON.parse(resp.body)
+    end
+
+    # @api private
+    # Search using an LDAP sync profile
+    #
+    # @param [String] profile name
+    # @param [Hash] options reserved
+    def ldap_sync_search(profile, options = {})
+      headers = credentials.dup.tap {|h|
+        h[:headers][:accept] = 'text/event-stream'
+      }
+
+      response = RestClient::Resource.new(Conjur.configuration.appliance_url, headers)['ldap-sync']['search'].post(options.merge(:config_name => profile))
+      JSON.parse(get_json("groups", response))
     end
 
     # @!endgroup
     
     private
-    def find_policy_event(response)
-      response.body.lines.find {|l| l =~ /^data: {"policy":/}.try(:[], 6..-1)
+    def get_json(ok_key, response)
+      if response.headers[:content_type] == 'text/event-stream'
+        find_ok_event(ok_key, response) || find_error_events(response)
+      else
+        %Q({"error": {"message": "Unexpected response from server: #{response.body}"}})
+      end    
+    end
+
+    def find_ok_event(key, response)
+      response.body.lines.find {|l| l =~ %r(^data: {"#{key}":) }.try(:[], 6..-1)
+    end
+
+    def find_log_events(response)
+      find_events(response, 'log').collect { |e| JSON.parse(e)['log'] }
     end
 
     def find_error_events(response)
+      find_events(response, "error").join("\n")
       response.body.lines.collect {|l| l.match(/^data: ({"error":.*)/).try(:[], 1)}.compact.join("\n")
     end
 
+    def find_events(response, key)
+      response.body.lines.collect {|l| l.match(/^data: ({"#{key}":.*)/).try(:[], 1)}.compact
+    end
   end
 end


### PR DESCRIPTION
Note that this functionality is currently tested by cukes in https://github.com/conjurinc/ldap-sync