### PR TITLE
Refresh token always when the token file mtime changes

### DIFF
--- a/conjur-api.gemspec
+++ b/conjur-api.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'redcarpet'
   gem.add_development_dependency 'tins', '~> 1.6', '< 1.7.0'
   gem.add_development_dependency 'inch'
+  gem.add_development_dependency 'fakefs'
 end


### PR DESCRIPTION
This avoids reading the token repeatedly even if it wasn't changed, and allows changing the token before it expires (eg. to switch identities).

Also get the mtime from the opened file instead of directory, so that it's accurate even if the file was replaced concurrently.